### PR TITLE
fix: fix candidate for a changelog generation issue

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -31,6 +31,9 @@ jobs:
         id: extractVersion
         run: echo "::set-output name=version::$(echo ${GITHUB_REF##*/release-})"
 
+      - name: Delete temporary trigger tag
+        run: git push origin --delete release-${{ steps.extractVersion.outputs.version }}
+
       - name: Bump version to ${{ steps.extractVersion.outputs.version }}
         run: |
           yarn lerna version ${{ steps.extractVersion.outputs.version }} --no-private --no-git-tag-version --no-push --yes
@@ -60,4 +63,3 @@ jobs:
         run: |
           git tag -a v${{ steps.extractVersion.outputs.version }} -m "tag release v${{ steps.extractVersion.outputs.version }}"
           git push --follow-tags
-          git push origin --delete release-${{ steps.extractVersion.outputs.version }}


### PR DESCRIPTION
It might be, that an intermediate tag, that is created and deleted during the release process, causes the changelog generation to not calc the correct diff.
The change itself should be harmless anyway, and we'll see next release if it improves things (@YonatanKra : if you can test it locally, please welcome to do so).