### PR TITLE
ci: slack now receives only conventional commit messages

### DIFF
--- a/scripts/release_announcer/slack_dispatcher.js
+++ b/scripts/release_announcer/slack_dispatcher.js
@@ -29,7 +29,7 @@ exports.releaseTemplate = ({ version, log_lines: rawLogLines })=>{
 	const
 		validLog = rawLogLines.filter(({ comment })=> !/(branch)|(pull request)/i.test(comment)),
 		bugs = validLog.filter(({ comment })=> /^fix(e[ds])?:/i.test(comment)).map(formatLogLine(':beetle:')),
-		features = validLog.filter(({ comment })=> /feat(ures?)?:/i.test(comment)).map(formatLogLine(':star:'));
+		features = validLog.filter(({ comment })=> /^feat(ures?)?:/i.test(comment)).map(formatLogLine(':star:'));
 
 	return {
 		"blocks": [


### PR DESCRIPTION
This avoids the issue where someone writes "fixed type" and it appears on slack. From now on, only conventional commit messages apply to features and bugs.