### PR TITLE
fix(slack-announcer): fixed commit message search pattern

### DIFF
--- a/scripts/release_announcer/slack_dispatcher.js
+++ b/scripts/release_announcer/slack_dispatcher.js
@@ -28,8 +28,8 @@ exports.releaseTemplate = ({ version, log_lines: rawLogLines })=>{
 
 	const
 		validLog = rawLogLines.filter(({ comment })=> !/(branch)|(pull request)/i.test(comment)),
-		bugs = validLog.filter(({ comment })=> /^fix(e[ds])?:/i.test(comment)).map(formatLogLine(':beetle:')),
-		features = validLog.filter(({ comment })=> /^feat(ures?)?:/i.test(comment)).map(formatLogLine(':star:'));
+		bugs = validLog.filter(({ comment })=> /^fix(e[ds])?.*?:/i.test(comment)).map(formatLogLine(':beetle:')),
+		features = validLog.filter(({ comment })=> /^feat(ures?)?.*?:/i.test(comment)).map(formatLogLine(':star:'));
 
 	return {
 		"blocks": [


### PR DESCRIPTION
Previous commit message search pattern did not match parenthesis following commit type.
For example 
`feat(module): something`
wasn't matched while
`feat: something`
did