### PR TITLE
fix: suspending the console absolutely

### DIFF
--- a/common/fonts/src/vvd-fonts.ts
+++ b/common/fonts/src/vvd-fonts.ts
@@ -10,8 +10,8 @@ let INIT_PROMISE: Promise<Record<string, unknown>> | null = null;
 async function init(): Promise<Record<string, unknown>> {
 	if (!INIT_PROMISE) {
 		INIT_PROMISE = new Promise((resolve, reject) => {
-			console.info('Vivid Fonts initialization start...');
-			const st = performance.now();
+			// console.info('Vivid Fonts initialization start...');
+			// const st = performance.now();
 
 			const testElement = setupInitTestElement();
 			const initialWidth = testElement.offsetWidth;
@@ -32,9 +32,9 @@ async function init(): Promise<Record<string, unknown>> {
 				.catch(reject)
 				.finally(() => {
 					cleanInitTestElement(testElement);
-					console.info(
-						`Vivid Fonts initialization took ${Math.floor(performance.now() - st)}ms`
-					);
+					// console.info(
+					// 	`Vivid Fonts initialization took ${Math.floor(performance.now() - st)}ms`
+					// );
 				});
 		});
 	}

--- a/common/scheme/src/vvd-scheme.ts
+++ b/common/scheme/src/vvd-scheme.ts
@@ -61,13 +61,13 @@ let setPromise: Promise<Record<string, unknown>> | null = null;
 async function set(
 	schemeOption: SchemeOption | null = null
 ): Promise<Record<string, unknown>> {
-	console.debug(`Vivid scheme requested to change to '${schemeOption}'...`);
+	// console.info(`Vivid scheme requested to change to '${schemeOption}'...`);
 
 	const effectiveOption = getEffectiveSchemeOption(schemeOption);
-	console.debug(`... which resolved effectively to '${effectiveOption}'...`);
+	// console.info(`... which resolved effectively to '${effectiveOption}'...`);
 
 	if (effectiveOption === _selectedSchemeOption && setPromise) {
-		console.debug('... new scheme option is equal to current, done');
+		// console.info('... new scheme option is equal to current, done');
 		return setPromise;
 	}
 
@@ -85,7 +85,7 @@ async function set(
 	}
 
 	setPromise = tmpPromise.then(() => {
-		console.debug('... scheme changed');
+		// console.info('... scheme changed');
 		return {
 			option: _selectedSchemeOption,
 			scheme: _selectedScheme,


### PR DESCRIPTION
Removing the console absolutely, it's annoying to customers, so we need to get it only when we have at least some naive logger with suspension mechanism.