### PR TITLE
fix(button): find the form dynamically on submit

### DIFF
--- a/components/button/src/vwc-button.ts
+++ b/components/button/src/vwc-button.ts
@@ -66,8 +66,12 @@ export class VWCButton extends MWCButton {
 	}
 
 	protected updateFormAndButton(): void {
+		const form = getFormByIdOrClosest((this as unknown) as HTMLInputElement);
+		if (form === this.form) {
+			return;
+		}
+		this.form = form;
 		this.#_hiddenButton?.remove();
-		this.form = getFormByIdOrClosest((this as unknown) as HTMLInputElement);
 		if (this.form && this.#_hiddenButton) {
 			this.form.appendChild(this.#_hiddenButton);
 		}
@@ -101,6 +105,8 @@ export class VWCButton extends MWCButton {
 	}
 
 	protected _handleClick(): void {
+		this.updateFormAndButton();
+
 		if (this.form) {
 			switch (this.getAttribute('type')) {
 				case 'reset':


### PR DESCRIPTION
Fixes a bug in which adding the form after the button was created was preventing form submit.