### PR TITLE
fix: replace moduleName calculation in a platform agnostic way

### DIFF
--- a/components/icon/build/vwc-icon-resolver-factory.js
+++ b/components/icon/build/vwc-icon-resolver-factory.js
@@ -97,7 +97,7 @@ const createDynamicResolver = function(){
 				.ignoreValues(),
 			iconStream
 				.flatMapConcurLimit(({ content, filename })=> {
-					const moduleName = [filename.match(/([^/]+)\..+$/)[1], "js"].join('.');
+					const moduleName = `${path.basename(filename, path.extname(filename))}.js`;
 					return kefir
 						.fromNodeCallback((cb)=> writeFile(path.join(baseModulePath, moduleName), esModuleTemplate(content), cb))
 						.map(()=> ({ type: "log", value: `"${moduleName}" module was created successfully` }));


### PR DESCRIPTION
Regexp were Unix specific, taking into account Unix slashes only as path delimiter.

For Windows it should be like that
/([^\/\\]+)\..+$/

And with all that, using native node path package is more reliable versus regexp in this case.