### PR TITLE
fix: annotate vwc-slider.ts events using JSDoc

### DIFF
--- a/components/slider/src/vwc-slider.ts
+++ b/components/slider/src/vwc-slider.ts
@@ -20,7 +20,7 @@ MWCSlider.styles = [styleCoupling, mwcSliderStyle, vwcSliderStyle];
  * This component is an extension of [<mwc-slider>](https://github.com/material-components/material-components-web-components/tree/master/packages/slider)
  * @fires change
  * @fires input
-*/
+ */
 @customElement('vwc-slider')
 export class VWCSlider extends MWCSlider {
 	async firstUpdated(): Promise<void> {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18071010/98956420-4bfc8480-2500-11eb-8d2c-2a1bf8b4e785.png)

Due to the way material component defines events, [WCA](https://www.npmjs.com/package/web-component-analyzer)
is not able to understand that. `...  as these not analyzed statically by this tool as of now ...`

So according to [JsDoc](https://www.npmjs.com/package/web-component-analyzer#%E2%9E%A4-how-to-document-your-components-using-jsdoc)

This should be done via Jsdoc annotations, for our [react wrappers generator](https://github.com/Vonage/vivid-react)
to be able to get those events from WCA output.