### PR TITLE
fix(slider): disabled slider tick color is equal to bg color which is…

### DIFF
--- a/components/slider/src/vwc-slider.scss
+++ b/components/slider/src/vwc-slider.scss
@@ -11,6 +11,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		color: var(--mdc-theme-text-primary-on-dark, white);
 		background-color: var(--mdc-theme-secondary);
 	}
 


### PR DESCRIPTION
… an issue for read-only control to display actual value

![slider tooltip bug](https://user-images.githubusercontent.com/18071010/103246989-9aa59700-4965-11eb-92bd-9296c35683bc.png)
