### PR TITLE
ci: adjusting the node js setup to latest action and node js 14

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
 
-      - name: Setup NodeJS 12
-        uses: actions/setup-node@v1
+      - name: Setup NodeJS 14
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Install yarn
         run: npm install -g yarn
@@ -53,7 +53,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Setup NodeJS 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -100,7 +100,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Setup NodeJS 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -147,7 +147,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Setup NodeJS 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -200,7 +200,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Setup NodeJS 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
@@ -245,7 +245,7 @@ jobs:
             token: ${{ secrets.PAT }}
 
         - name: Setup NodeJS 14
-          uses: actions/setup-node@v1
+          uses: actions/setup-node@v2
           with:
             node-version: 14
 

--- a/.github/workflows/deploy-showcase-dev-s3.yml
+++ b/.github/workflows/deploy-showcase-dev-s3.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup NodeJS 12
-        uses: actions/setup-node@v1
+      - name: Setup NodeJS 14
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Install yarn
         run: npm install -g yarn

--- a/.github/workflows/deploy-showcase-pr-s3.yml
+++ b/.github/workflows/deploy-showcase-pr-s3.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup NodeJS 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/post-merge-code-coverage.yml
+++ b/.github/workflows/post-merge-code-coverage.yml
@@ -19,7 +19,7 @@ jobs:
           ref: master
 
       - name: Setup NodeJS 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -19,10 +19,10 @@ jobs:
           ref: master
           token: ${{ secrets.CI_AT }}
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Install yarn
         run: npm install -g yarn

--- a/.github/workflows/release-publish-npm.yml
+++ b/.github/workflows/release-publish-npm.yml
@@ -18,10 +18,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CI_AT }}
 
-      - name: Setup NodeJS 12
-        uses: actions/setup-node@v1
+      - name: Setup NodeJS 14
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Install yarn
         run: npm install -g yarn

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CI_AT }}
 
-      - name: Setup NodeJS 12
-        uses: actions/setup-node@v1
+      - name: Setup NodeJS 14
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Install yarn
         run: npm install -g yarn


### PR DESCRIPTION
The setup NodeJS action is became v2 since we've started to use it.
NodeJS self released LTS 14.

So this PR is bumping those 2 to keep up with the latest.