### PR TITLE
fix(vwc-note): issue 675 / viv-415 fixing the color strip for Safari 13.1

### DIFF
--- a/components/note/src/vwc-note.scss
+++ b/components/note/src/vwc-note.scss
@@ -14,7 +14,6 @@ $border-value: 8px solid var(#{color-semantic.$vvd-color-connotation});
 	padding: 20px;
 	border-left: $border-value;
 	background-color: var(#{scheme-variables.$vvd-color-base});
-	border-inline-start: $border-value;
 	border-radius: 6px;
 	box-shadow: inset 0 1px 0 0 var(#{scheme-variables.$vvd-color-contrast-tinged}),
 		inset -1px 0 0 0 var(#{scheme-variables.$vvd-color-contrast-tinged}),


### PR DESCRIPTION
closes #675 