### PR TITLE
fix(note): issue #678 - explicitly aligning note contents by default

### DIFF
--- a/components/note/src/vwc-note.scss
+++ b/components/note/src/vwc-note.scss
@@ -34,6 +34,7 @@ $border-value: 8px solid var(#{color-semantic.$vvd-color-connotation});
 	flex: 1;
 	flex-direction: column;
 	justify-content: center;
+	text-align: start;
 
 	.note-header {
 		@include typography.typography-cat-shorthand('body-2-bold');

--- a/components/note/test/note.test.js
+++ b/components/note/test/note.test.js
@@ -67,6 +67,20 @@ describe('note', () => {
 		});
 	});
 
+	it('should heve text aligned correctly (start)', async () => {
+		const [wrapper] = addElement(
+			textToDomToParent(`
+				<div style="text-align: center !important">
+					<${COMPONENT_NAME} header="Header"><p>Internal contents</p></${COMPONENT_NAME}>
+				</div>`)
+		);
+		await waitNextTask();
+		const note = wrapper.firstElementChild;
+		expect(note).exist;
+		assertComputedStyle(note.shadowRoot.querySelector('.note-header'), { textAlign: 'start' });
+		assertComputedStyle(note.firstElementChild, { textAlign: 'start' });
+	});
+
 	describe('header', () => {
 		it('should have header when header is set', async () => {
 			const [note] = addElement(


### PR DESCRIPTION
closes #678 

This will still allow consumers to override the styling of the slotted content, if needed, but as an untouched default it'll keep our design.