### PR TITLE
chore(data-grid, checkbox): improving the checkbox imports in data-grid

### DIFF
--- a/components/checkbox/src/vwc-checkbox.ts
+++ b/components/checkbox/src/vwc-checkbox.ts
@@ -6,6 +6,8 @@ import { style as mwcCheckboxStyle } from '@material/mwc-checkbox/mwc-checkbox-c
 import { style as styleCoupling } from '@vonage/vvd-style-coupling';
 import { handleAutofocus } from '@vonage/vvd-foundation/general-utils';
 
+export const COMPONENT_NAME = 'vwc-checkbox';
+
 declare global {
 	interface HTMLElementTagNameMap {
 		'vwc-checkbox': VWCCheckbox;

--- a/components/checkbox/test/checkbox.test.js
+++ b/components/checkbox/test/checkbox.test.js
@@ -1,4 +1,4 @@
-import '../vwc-checkbox.js';
+import { COMPONENT_NAME } from '../vwc-checkbox.js';
 import {
 	textToDomToParent,
 	waitNextTask,
@@ -7,8 +7,6 @@ import {
 import { chaiDomDiff } from '@open-wc/semantic-dom-diff';
 
 chai.use(chaiDomDiff);
-
-const COMPONENT_NAME = 'vwc-checkbox';
 
 describe('checkbox', () => {
 	const addElement = isolatedElementsCreation();

--- a/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-cell-vaadin.ts
+++ b/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-cell-vaadin.ts
@@ -1,10 +1,7 @@
-import '@vonage/vwc-checkbox';
-import { VWCCheckbox } from '@vonage/vwc-checkbox';
+import { VWCCheckbox, COMPONENT_NAME as CHECKBOX_COMPONENT } from '@vonage/vwc-checkbox';
 import { DataGridColumn, SELECTOR_SINGLE } from '../../vwc-data-grid-column-api';
 import { DataRenderer, RendererConfiguration } from '../../vwc-data-grid-renderer-api';
 import { DataRendererProvider } from '../vwc-data-grid-render-provider-api';
-
-const CHECKBOX_COMPONENT = 'vwc-checkbox';
 
 export {
 	cellRendererProvider

--- a/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-header-vaadin.ts
+++ b/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-header-vaadin.ts
@@ -1,11 +1,8 @@
-import '@vonage/vwc-checkbox';
-import { VWCCheckbox } from '@vonage/vwc-checkbox';
+import { VWCCheckbox, COMPONENT_NAME as CHECKBOX_COMPONENT } from '@vonage/vwc-checkbox';
 import { GRID_HEADER_COMPONENT } from '../../vwc-data-grid-api';
 import { DataGridColumn, SELECTOR_MULTI, SELECTOR_SINGLE } from '../../vwc-data-grid-column-api';
 import { MetaRendererProvider } from '../vwc-data-grid-render-provider-api';
 import { MetaRenderer, RendererConfiguration } from '../../vwc-data-grid-renderer-api';
-
-const CHECKBOX_COMPONENT = 'vwc-checkbox';
 
 export {
 	headerRendererProvider


### PR DESCRIPTION
While my prev attempt to use component name as a single constant failed the 'vivid all' packages (which we still need to discuss regardless of this PR), I think that present syntax still beneficial:
* we do have a single constant component name definition which is provided by component package - reasonably
* we can get rid of double import of the checkbox in the grid components (needed due to TS/JS discrepancy)
* we can actually use this constant in test also, which we already have defining this constant on its own

I also suggest for a near future:
* discuss this practice to be our common practice in the rest of the components
* see how 'vivid all' packager can still work with this syntax (or otherwise)