### PR TITLE
fix(datepicker): viv-446 remove vertical scrollbar in time picker

### DIFF
--- a/components/datepicker/src/vwc-datepicker.scss
+++ b/components/datepicker/src/vwc-datepicker.scss
@@ -30,7 +30,6 @@ vwc-menu {
 	color: var(#{scheme-variables.$vvd-color-on-base});
 
 	&::before,
- 
 	&::after {
 		display: none;
 	}


### PR DESCRIPTION
flatpickr uses pseudo elements for arrows in their design.
We don't use them and they cause a scrollbar in our time picker.