### PR TITLE
fix(datepicker): remove background colour on inline mode month view

### DIFF
--- a/components/datepicker/src/vwc-datepicker.scss
+++ b/components/datepicker/src/vwc-datepicker.scss
@@ -257,6 +257,7 @@ vwc-menu {
 				position: relative;
 				top: 0;
 				padding: 40px 0 0;
+				background: none;
 			}
 		}
 	}


### PR DESCRIPTION
inline mode datepicker shouldn't have a background colour:

![image](https://user-images.githubusercontent.com/10006963/117233441-3fd1fe00-ae77-11eb-9a94-0b0d36adefb8.png)
