### PR TITLE
chore(ci): optimize ci runs

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -2,6 +2,7 @@ name: Compile & Test
 
 on:
   pull_request:
+    types: [opened, synchronize, edited, reopned]
     branches:
       - master
 


### PR DESCRIPTION
@Roee-Malis noticed that Vonage's github action quota is being used excessively:
![image](https://user-images.githubusercontent.com/51640960/122062274-f1aa0600-cdf7-11eb-810c-ad7c26c02726.jpeg)

pull_request event has many different activity types that might not be relevant, watch: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request