### PR TITLE
chore(workspace): removed depcheck from "pr to master" workflow

### DIFF
--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -124,8 +124,6 @@ jobs:
           - dep-check
           - lint
         include:
-          - script: dep-check
-            script_name: Test package dependencies
           - script: lint
             script_name: Test Lint rules
     steps:


### PR DESCRIPTION
Removed "depcheck" from "pr to master" CI routine