### PR TITLE
chore(workspace): separated type imports/exports

### DIFF
--- a/components/badge/src/vwc-badge-base.ts
+++ b/components/badge/src/vwc-badge-base.ts
@@ -2,7 +2,8 @@ import {
 	html, LitElement, property, TemplateResult
 } from 'lit-element';
 import { nothing } from 'lit-html';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import type { Connotation, Shape, Layout } from '@vonage/vvd-foundation/constants';
 import { handleMultipleDenseProps } from '@vonage/vvd-foundation/general-utils';
 

--- a/components/button-toggle-group/src/vwc-button-toggle-group.ts
+++ b/components/button-toggle-group/src/vwc-button-toggle-group.ts
@@ -1,6 +1,7 @@
 import {
-	customElement, html, LitElement, property, PropertyValues
+	customElement, html, LitElement, property,
 } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 import { style } from './vwc-button-toggle-group.css.js';
 
 declare global {

--- a/components/carousel/src/vwc-carousel.ts
+++ b/components/carousel/src/vwc-carousel.ts
@@ -10,8 +10,9 @@ import {
 } from 'lit-element';
 import { style } from './vwc-carousel.css.js';
 import SwiperCore, {
-	Swiper, SwiperOptions, Autoplay, Keyboard, Mousewheel, Navigation
+	Swiper, Autoplay, Keyboard, Mousewheel, Navigation
 } from 'swiper/core';
+import type { SwiperOptions } from 'swiper/core';
 import '@vonage/vwc-icon';
 import './vwc-carousel-item.js';
 

--- a/components/data-grid/src/adapters/vaadin/vwc-data-grid-adapter-vaadin.ts
+++ b/components/data-grid/src/adapters/vaadin/vwc-data-grid-adapter-vaadin.ts
@@ -3,11 +3,12 @@ import '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
 import '@vaadin/vaadin-grid/src/vaadin-grid-tree-column.js';
 import '../../headers/vwc-data-grid-header.js';
 import {
-	DataGrid, EventContext, GRID_COMPONENT, GRID_ENGINE_ROOT_CLASS
+	GRID_COMPONENT, GRID_ENGINE_ROOT_CLASS
 } from '../../vwc-data-grid-api.js';
 import type { GridElement } from '@vaadin/vaadin-grid/src/vaadin-grid.js';
 import type { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
 import type { GridEventContext } from '@vaadin/vaadin-grid/src/interfaces.js';
+import type { EventContext, DataGrid } from '../../vwc-data-grid-api.js';
 import type { DataGridColumn } from '../../vwc-data-grid-column-api.js';
 import type { DataGridAdapter } from '../vwc-data-grid-adapter-api.js';
 import type { MetaRendererProvider, DataRendererProvider, RowDetailsRendererProvider } from '../vwc-data-grid-render-provider-api.js';

--- a/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-cell-vaadin.ts
+++ b/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-cell-vaadin.ts
@@ -1,5 +1,6 @@
 import { VWCCheckbox, COMPONENT_NAME as CHECKBOX_COMPONENT } from '@vonage/vwc-checkbox';
-import { DataGridColumn, SELECTOR_SINGLE } from '../../vwc-data-grid-column-api.js';
+import { SELECTOR_SINGLE } from '../../vwc-data-grid-column-api.js';
+import type { DataGridColumn } from '../../vwc-data-grid-column-api.js';
 import type { DataRenderer, CellRendererConfiguration } from '../../vwc-data-grid-renderer-api.js';
 import type { DataRendererProvider } from '../vwc-data-grid-render-provider-api.js';
 

--- a/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-header-vaadin.ts
+++ b/components/data-grid/src/adapters/vaadin/vwc-renderer-provider-header-vaadin.ts
@@ -1,6 +1,8 @@
 import { VWCCheckbox, COMPONENT_NAME as CHECKBOX_COMPONENT } from '@vonage/vwc-checkbox';
-import { DataGrid, GRID_HEADER_COMPONENT } from '../../vwc-data-grid-api.js';
-import { DataGridColumn, SELECTOR_MULTI, SELECTOR_SINGLE } from '../../vwc-data-grid-column-api.js';
+import { GRID_HEADER_COMPONENT } from '../../vwc-data-grid-api.js';
+import type { DataGrid } from '../../vwc-data-grid-api.js';
+import { SELECTOR_MULTI, SELECTOR_SINGLE } from '../../vwc-data-grid-column-api.js';
+import type { DataGridColumn } from '../../vwc-data-grid-column-api.js';
 import type { MetaRendererProvider } from '../vwc-data-grid-render-provider-api.js';
 import type { MetaRenderer, CellRendererConfiguration } from '../../vwc-data-grid-renderer-api.js';
 

--- a/components/data-grid/src/headers/vwc-data-grid-header.ts
+++ b/components/data-grid/src/headers/vwc-data-grid-header.ts
@@ -1,15 +1,16 @@
 import '@vonage/vvd-core';
 import '@vonage/vwc-icon';
-import { DataGridHeader, GRID_HEADER_COMPONENT } from '../vwc-data-grid-api.js';
+import { GRID_HEADER_COMPONENT } from '../vwc-data-grid-api.js';
+import type { DataGridHeader } from '../vwc-data-grid-api.js';
 import { style as vwcDataGridHeaderStyle } from './vwc-data-grid-header.css.js';
 import {
 	html,
 	customElement,
 	property,
 	LitElement,
-	PropertyValues,
 	TemplateResult,
 } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/components/data-grid/src/vwc-data-grid-api.ts
+++ b/components/data-grid/src/vwc-data-grid-api.ts
@@ -6,6 +6,9 @@ export {
 	GRID_HEADER_COMPONENT,
 	GRID_SELECT_HEADER_COMPONENT,
 	GRID_ENGINE_ROOT_CLASS,
+};
+
+export type {
 	DataGrid,
 	DataGridHeader,
 	EventContext,

--- a/components/data-grid/src/vwc-data-grid-column.ts
+++ b/components/data-grid/src/vwc-data-grid-column.ts
@@ -2,9 +2,9 @@ import {
 	COLUMN_DEFINITION_COMPONENT,
 	COLUMN_DEFINITION_UPDATE_EVENT,
 	SELECTOR_SINGLE,
-	SELECTOR_MULTI,
-	DataGridColumn
+	SELECTOR_MULTI
 } from './vwc-data-grid-column-api.js';
+import type { DataGridColumn } from './vwc-data-grid-column-api.js';
 import {
 	customElement,
 	property,

--- a/components/data-grid/src/vwc-data-grid.ts
+++ b/components/data-grid/src/vwc-data-grid.ts
@@ -2,7 +2,9 @@ import '@vonage/vvd-core';
 import './vwc-data-grid-column.js';
 import {
 	GRID_COMPONENT,
-	GRID_ENGINE_ROOT_CLASS,
+	GRID_ENGINE_ROOT_CLASS
+} from './vwc-data-grid-api.js';
+import type {
 	DataGrid,
 	DataGridHeader,
 	EventContext
@@ -10,8 +12,8 @@ import {
 import {
 	COLUMN_DEFINITION_COMPONENT,
 	COLUMN_DEFINITION_UPDATE_EVENT,
-	DataGridColumn,
 } from './vwc-data-grid-column-api.js';
+import type { DataGridColumn } from './vwc-data-grid-column-api.js';
 import type { RowDetailsRenderer } from './vwc-data-grid-renderer-api.js';
 import { VWCDataGridAdapterVaadin } from './adapters/vaadin/vwc-data-grid-adapter-vaadin.js';
 import { style as vwcDataGridStyle } from './vwc-data-grid.css.js';

--- a/components/dialog/src/vwc-dialog.ts
+++ b/components/dialog/src/vwc-dialog.ts
@@ -1,4 +1,5 @@
-import { customElement, property, PropertyValues } from 'lit-element';
+import { customElement, property } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 import { style } from './vwc-dialog.css.js';
 import { Dialog as MWCDialog } from '@material/mwc-dialog';
 import { styles as mwcDialogStyles } from '@material/mwc-dialog/mwc-dialog.css.js';

--- a/components/icon-button-toggle/src/vwc-icon-button-toggle.ts
+++ b/components/icon-button-toggle/src/vwc-icon-button-toggle.ts
@@ -4,7 +4,8 @@ import '@material/mwc-ripple';
 import {
 	html,	customElement, property, TemplateResult, CSSResult
 } from 'lit-element';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { nothing } from 'lit-html';
 import { IconButtonToggleBase } from '@material/mwc-icon-button-toggle/mwc-icon-button-toggle-base.js';

--- a/components/layout/src/vwc-layout.ts
+++ b/components/layout/src/vwc-layout.ts
@@ -7,7 +7,7 @@ import {
 } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import type { ClassInfo } from 'lit-html/directives/class-map';
-import { Size } from '@vonage/vvd-foundation/constants';
+import { Size } from '@vonage/vvd-foundation/constants.js';
 import { style } from './vwc-layout.css.js';
 
 

--- a/components/list/src/vwc-list-expansion-panel.ts
+++ b/components/list/src/vwc-list-expansion-panel.ts
@@ -2,10 +2,10 @@ import type { VWCIcon } from '@vonage/vwc-icon';
 import {
 	customElement,
 	html,
-	PropertyValues,
 	queryAssignedNodes,
 	TemplateResult,
 } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 import { style } from './vwc-list-expansion-panel.css.js';
 import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import { VWCExpansionPanelBase } from '@vonage/vwc-expansion-panel/vwc-expansion-panel-base';

--- a/components/note/src/vwc-note.ts
+++ b/components/note/src/vwc-note.ts
@@ -3,9 +3,10 @@ import '@vonage/vwc-icon';
 import {
 	customElement, property, LitElement, CSSResult, html, TemplateResult
 } from 'lit-element';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import { style as vwcNoteStyle } from './vwc-note.css.js';
-import type { Connotation } from '@vonage/vvd-foundation/constants';
+import type { Connotation } from '@vonage/vvd-foundation/constants.js';
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/components/pagination/src/vwc-pagination.ts
+++ b/components/pagination/src/vwc-pagination.ts
@@ -3,8 +3,9 @@ import '@vonage/vwc-icon';
 // import '@material/mwc-ripple';
 import type { Ripple } from '@material/mwc-ripple';
 import {
-	customElement, property, LitElement, CSSResult, PropertyValues, html, TemplateResult
+	customElement, property, LitElement, CSSResult, html, TemplateResult
 } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 import { style } from './vwc-pagination.css.js';
 
 export const COMPONENT_NAME = 'vwc-pagination';

--- a/components/scheme-select/src/vwc-scheme-select.ts
+++ b/components/scheme-select/src/vwc-scheme-select.ts
@@ -6,8 +6,8 @@ import {
 import vvdScheme, {
 	AutoScheme,
 	PredefinedScheme,
-	SchemeOption,
 } from '@vonage/vvd-scheme';
+import type { SchemeOption } from '@vonage/vvd-scheme';
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/components/select/src/vwc-select.ts
+++ b/components/select/src/vwc-select.ts
@@ -6,9 +6,9 @@ import {
 	customElement,
 	property,
 	html,
-	TemplateResult,
-	PropertyValues,
+	TemplateResult
 } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 import { Select as MWCSelect } from '@material/mwc-select';
 import { style as styleCoupling } from '@vonage/vvd-style-coupling/mdc-vvd-coupling.css.js';
 import { style as vwcSelectStyle } from './vwc-select.css.js';

--- a/components/snackbar/src/vwc-snackbar.ts
+++ b/components/snackbar/src/vwc-snackbar.ts
@@ -9,7 +9,8 @@ import {
 	property,
 	TemplateResult,
 } from 'lit-element';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { SnackbarBase as MWCSnackbarBase } from '@material/mwc-snackbar/mwc-snackbar-base';
 import { style as vwcSnackbarStyle } from './vwc-snackbar.css.js';

--- a/components/switch/src/vwc-switch.ts
+++ b/components/switch/src/vwc-switch.ts
@@ -2,7 +2,8 @@ import '@vonage/vvd-core';
 import {
 	customElement, property, html, TemplateResult
 } from 'lit-element';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { Switch as MWCSwitch } from '@material/mwc-switch';
 import { style as vwcSwitchStyle } from './vwc-switch.css.js';

--- a/components/tags/src/vwc-tag-base.ts
+++ b/components/tags/src/vwc-tag-base.ts
@@ -3,7 +3,8 @@ import type { Ripple } from '@material/mwc-ripple/mwc-ripple';
 import { RippleHandlers } from '@material/mwc-ripple/ripple-handlers';
 
 import type { Connotation, Shape, Layout } from '@vonage/vvd-foundation/constants';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import {
 	 LitElement, html, property, TemplateResult, queryAsync, state, query, eventOptions
 } from 'lit-element';

--- a/components/text/src/vwc-text-base.ts
+++ b/components/text/src/vwc-text-base.ts
@@ -3,7 +3,8 @@ import type { VVDFontFace } from '@vonage/vvd-design-tokens/build/types/font-fac
 import {
 	html, LitElement, property, TemplateResult
 } from 'lit-element';
-import { ClassInfo, classMap } from 'lit-html/directives/class-map';
+import { classMap } from 'lit-html/directives/class-map';
+import type { ClassInfo } from 'lit-html/directives/class-map';
 import type { Connotation } from '@vonage/vvd-foundation/constants';
 
 type TextConnotation = Extract<

--- a/components/textfield/src/vwc-textfield.ts
+++ b/components/textfield/src/vwc-textfield.ts
@@ -8,11 +8,11 @@ import {
 	property,
 	html,
 	TemplateResult,
-	PropertyValues,
 	queryAssignedNodes,
 	query,
 	internalProperty
 } from 'lit-element';
+import type { PropertyValues } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 
 import { TextField as MWCTextField } from '@material/mwc-textfield';
@@ -22,7 +22,7 @@ import { styles as mwcTextFieldStyles } from '@material/mwc-textfield/mwc-textfi
 import type { Shape } from '@vonage/vvd-foundation/constants';
 import { debounced, handleAutofocus } from '@vonage/vvd-foundation/general-utils';
 
-export { TextFieldType } from '@material/mwc-textfield';
+export type { TextFieldType } from '@material/mwc-textfield';
 
 export const COMPONENT_NAME = 'vwc-textfield';
 export const VALID_BUTTON_ELEMENTS = ['vwc-icon-button'];

--- a/components/theme-switch/src/vwc-theme-switch.ts
+++ b/components/theme-switch/src/vwc-theme-switch.ts
@@ -11,9 +11,9 @@ import { style } from './vwc-theme-switch.css.js';
 import {
 	default as vvdScheme,
 	PredefinedScheme,
-	SchemeOption,
-	SelectedDetail,
 } from '@vonage/vvd-scheme/vvd-scheme.js';
+
+import type { SchemeOption, SelectedDetail } from '@vonage/vvd-scheme/vvd-scheme.js';
 
 const VVD_SCHEME_SELECT = 'vvd-scheme-select',
 	EVENT_LISTENER_KEY = Symbol('scheme.select.listener');


### PR DESCRIPTION
while examining code transpilers other than Typescript's, it became apparent that keeping a well-declared separation between code and type is very handy.

This implements https://jira.vonage.com/browse/VIV-743 and continues @yinonov #1072