### PR TITLE
build(typescript): downgrade root to version in packages

### DIFF
--- a/components/icon/src/vwc-icon.ts
+++ b/components/icon/src/vwc-icon.ts
@@ -80,7 +80,7 @@ export class VWCIcon extends LitElement {
 		attribute: 'aria-label',
 		type: String,
 	})
-	override ariaLabel = '';
+		ariaLabel = '';
 
 	protected getRenderClasses(): ClassInfo {
 		return {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
 		"ts-loader": "^9.1.2",
 		"ts-node": "^9.1.1",
 		"tslib": "^2.3.0",
-		"typescript": "^4.4.4",
+		"typescript": "^4.3.2",
 		"uuid": "^8.3.2",
 		"web-component-analyzer": "^1.1.6",
 		"webpack-cli": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18624,11 +18624,6 @@ typescript@^4.3.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
-typescript@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
 typical@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"


### PR DESCRIPTION
same issues referenced in material-components/material-web#2681

downgrade of typescript to same version in packages