### PR TITLE
fix(elevation): remove un-needed width style

### DIFF
--- a/components/elevation/src/vwc-elevation.scss
+++ b/components/elevation/src/vwc-elevation.scss
@@ -26,6 +26,5 @@ $elevation-border-radius: --elevation-border-radius;
 
 .vwc-elevation {
 	--elevation-border-radius: 6px;
-	width: fit-content;
 	border-radius: var(#{--elevation-border-radius});
 }

--- a/components/elevation/stories/elevation.stories.js
+++ b/components/elevation/stories/elevation.stories.js
@@ -12,6 +12,9 @@ export default {
 const dpLevels = [0, 2, 4, 8, 12, 16, 24];
 const styles = () => html`
 	<style>
+		vwc-elevation {
+			display: inline-block;
+		}
 
 		.wrapper {
 			display: grid;


### PR DESCRIPTION
Width property was added because of a story bug but it is not right to set it. 
Removed it and fixed the story.