### PR TITLE
feat(tags): support removable

### DIFF
--- a/components/fab/src/vwc-fab.scss
+++ b/components/fab/src/vwc-fab.scss
@@ -30,6 +30,8 @@
 		--mdc-fab-box-shadow: 0 none;
 		@include connotation.connotation;
 		@include typography.typography-cat-shorthand('body-2-bold');
+		width: 40px;
+		height: 40px;
 		box-shadow: 0 none;
 		filter: var(#{scheme-variables.$vvd-shadow-surface-4dp});
 

--- a/components/tags/src/vwc-tag-base.ts
+++ b/components/tags/src/vwc-tag-base.ts
@@ -8,6 +8,7 @@ import type { ClassInfo } from 'lit-html/directives/class-map.js';
 import {
 	LitElement, html, property, TemplateResult, queryAsync, state, query, eventOptions
 } from 'lit-element';
+import { nothing } from 'lit-html';
 
 
 type TagConnotation = Extract<
@@ -43,6 +44,9 @@ export class VWCTagBase extends LitElement {
 
 	@property({ type: Boolean, reflect: true })
 		selectable = false;
+
+	@property({ type: Boolean, reflect: true })
+		removable = false;
 
 	@state() protected shouldRenderRipple = false;
 
@@ -120,11 +124,18 @@ export class VWCTagBase extends LitElement {
 		</span>`;
 	}
 
+	protected renderRemoveButton(): TemplateResult {
+		return html`<button class="remove-button" @click="${()=> this.remove()}">
+			${this.renderIcon('close-line')}
+		</button>`;
+	}
+
 	override render(): TemplateResult {
 		return this.selectable
 			? this.renderTagSelectable()
 			: html`<span class="vwc-tag ${classMap(this.getRenderClasses())}">
 			${this.text}
+			${this.removable ? this.renderRemoveButton() : nothing}
 		</span>`;
 	}
 

--- a/components/tags/src/vwc-tag.scss
+++ b/components/tags/src/vwc-tag.scss
@@ -126,3 +126,11 @@
 // 	}
 // }
 
+.remove-button {
+	all: unset;
+	margin-inline-start: 10px;
+
+	.vwc-tag__icon {
+		--vvd-icon-size: 10px;
+	}
+}

--- a/components/tags/stories/tag.stories.js
+++ b/components/tags/stories/tag.stories.js
@@ -25,3 +25,6 @@ Outlined.args = { text: 'Outlined',	layout: 'outlined' };
 
 export const Selected = Template.bind({});
 Selected.args = { text: 'Selected', selectable: true, selected: true };
+
+export const Removable = Template.bind({});
+Removable.args = { text: 'Removable', Removable: true };


### PR DESCRIPTION
issues to resolve:

- [ ] tags wrapper to observe assigned nodes (measure performance of textContent tags instances / manage state of assigned tags) @yonatankra
- [ ] consider removing dense / enlarge if not required at this point @jshenkman
- [ ] research focus management in accordance to keyboard control @yinonov
- [ ] should remove button feature ripple as well? @rachelbt
- [ ] should selected feature ripple? @rachelbt